### PR TITLE
Supports GHC 8.8

### DIFF
--- a/src/Data/Textual.hs
+++ b/src/Data/Textual.hs
@@ -410,7 +410,7 @@ parse p i = runParser p [] 0 i (\_  _ _ a → Parsed a)
 {-# INLINE parse #-}
 
 -- | Use the built-in parser to parse a string. Intended for testing only.
-builtInParser ∷ (∀ μ . (Monad μ, CharParsing μ) ⇒ μ α) → String → Parsed α
+builtInParser ∷ (∀ μ . (MonadFail μ, CharParsing μ) ⇒ μ α) → String → Parsed α
 builtInParser p = parse p
 {-# INLINE builtInParser #-}
 

--- a/src/Data/Textual.hs
+++ b/src/Data/Textual.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE UnicodeSyntax #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor #-}
@@ -60,11 +61,13 @@ module Data.Textual
   , fromLazyUtf8As
   ) where
 
-import Prelude hiding (print)
+import Prelude hiding (fail, print)
 import Data.Typeable (Typeable)
+#if !MIN_VERSION_base(4, 13, 0)
 import Data.Foldable (Foldable)
 import Data.Traversable (Traversable)
 import Data.Monoid (mempty)
+#endif
 import Data.Int
 import Data.Word
 import Data.Ratio (Ratio)
@@ -80,6 +83,7 @@ import Data.Text.Lazy.Encoding (decodeUtf8)
 import Data.Textual.Integral
 import Data.Textual.Fractional
 import Control.Applicative
+import Control.Monad.Fail (MonadFail (fail))
 import qualified Text.Printer as TP
 import qualified Text.Printer.Integral as TP
 import qualified Text.Printer.Fractional as TP
@@ -213,7 +217,7 @@ toLazyUtf8 = TP.buildLazyUtf8 . print
 --     'fromString' ('toString' /x/) = 'Just' /x/
 --   @
 class Printable α ⇒ Textual α where
-  textual ∷ (Monad μ, CharParsing μ) ⇒ μ α
+  textual ∷ (MonadFail μ, CharParsing μ) ⇒ μ α
 
 instance Textual Char where
   textual = PC.anyChar
@@ -395,6 +399,8 @@ instance Monad Parser where
   {-# INLINE (>>=) #-}
   (>>) = (*>)
   {-# INLINE (>>) #-}
+
+instance MonadFail Parser where
   fail = PC.unexpected
   {-# INLINE fail #-}
 

--- a/src/Data/Textual/Integral.hs
+++ b/src/Data/Textual/Integral.hs
@@ -86,11 +86,13 @@ module Data.Textual.Integral
   , cbBits
   ) where
 
+import Prelude hiding (fail)
 import Data.Typeable (Typeable)
 import Data.Int
 import Data.Word
 import Data.Bits (Bits(..))
 import Control.Applicative
+import Control.Monad.Fail (MonadFail (fail))
 import Text.Printer.Integral (
          PositionalSystem(..), BitSystem(..),
          Binary(..), Octal(..), Decimal(..), Hexadecimal(..),
@@ -174,33 +176,33 @@ nzUpHexDigit = nzDigitIn UpHex
 
 -- | Parse a non-negative number written in the specified positional
 --   numeral system.
-nonNegative ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ) ⇒ s → μ α
+nonNegative ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ) ⇒ s → μ α
 nonNegative s = digit >>= go <?> systemName s ++ " digits"
   where go !r = optional digit >>= \case
                   Just d  → go (r * radix + d)
                   Nothing → return r
         radix = radixIn s
         digit = digitIn s
-{-# SPECIALIZE nonNegative ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int #-}
-{-# SPECIALIZE nonNegative ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
-{-# SPECIALIZE nonNegative ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
-{-# SPECIALIZE nonNegative ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
-{-# SPECIALIZE nonNegative ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
-{-# SPECIALIZE nonNegative ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word #-}
-{-# SPECIALIZE nonNegative ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
-{-# SPECIALIZE nonNegative ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
-{-# SPECIALIZE nonNegative ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
-{-# SPECIALIZE nonNegative ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
-{-# SPECIALIZE nonNegative ∷ (Num α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE nonNegative ∷ (Num α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE nonNegative ∷ (Num α, Monad μ, CharParsing μ) ⇒ Decimal → μ α #-}
-{-# SPECIALIZE nonNegative ∷ (Num α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE nonNegative ∷ (Num α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE nonNegative ∷ (Num α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE nonNegative ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int #-}
+{-# SPECIALIZE nonNegative ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
+{-# SPECIALIZE nonNegative ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
+{-# SPECIALIZE nonNegative ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
+{-# SPECIALIZE nonNegative ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
+{-# SPECIALIZE nonNegative ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word #-}
+{-# SPECIALIZE nonNegative ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
+{-# SPECIALIZE nonNegative ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
+{-# SPECIALIZE nonNegative ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
+{-# SPECIALIZE nonNegative ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
+{-# SPECIALIZE nonNegative ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE nonNegative ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE nonNegative ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Decimal → μ α #-}
+{-# SPECIALIZE nonNegative ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE nonNegative ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE nonNegative ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-negative number written in the specified positional
 --   numeral system. Leading zeroes are not allowed.
-nnCompact ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ) ⇒ s → μ α
+nnCompact ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ) ⇒ s → μ α
 nnCompact s = (<?> systemName s ++ " digits") $ digitIn s >>= \case
                 0 → optional (PC.satisfy $ isDigitIn s) >>= \case
                       Just _  → PC.unexpected "leading zero"
@@ -211,22 +213,22 @@ nnCompact s = (<?> systemName s ++ " digits") $ digitIn s >>= \case
                   Nothing → return r
         radix = radixIn s
         digit = digitIn s
-{-# SPECIALIZE nnCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int #-}
-{-# SPECIALIZE nnCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
-{-# SPECIALIZE nnCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
-{-# SPECIALIZE nnCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
-{-# SPECIALIZE nnCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
-{-# SPECIALIZE nnCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word #-}
-{-# SPECIALIZE nnCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
-{-# SPECIALIZE nnCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
-{-# SPECIALIZE nnCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
-{-# SPECIALIZE nnCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
-{-# SPECIALIZE nnCompact ∷ (Num α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE nnCompact ∷ (Num α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE nnCompact ∷ (Num α, Monad μ, CharParsing μ) ⇒ Decimal → μ α #-}
-{-# SPECIALIZE nnCompact ∷ (Num α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE nnCompact ∷ (Num α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE nnCompact ∷ (Num α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE nnCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int #-}
+{-# SPECIALIZE nnCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
+{-# SPECIALIZE nnCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
+{-# SPECIALIZE nnCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
+{-# SPECIALIZE nnCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
+{-# SPECIALIZE nnCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word #-}
+{-# SPECIALIZE nnCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
+{-# SPECIALIZE nnCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
+{-# SPECIALIZE nnCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
+{-# SPECIALIZE nnCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
+{-# SPECIALIZE nnCompact ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE nnCompact ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE nnCompact ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Decimal → μ α #-}
+{-# SPECIALIZE nnCompact ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE nnCompact ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE nnCompact ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 moreThan ∷ CharParsing μ ⇒ Int → μ α
 moreThan n = PC.unexpected
@@ -238,7 +240,7 @@ moreThan n = PC.unexpected
 
 -- | Parse a non-negative number written in the specified positional
 --   numeral system (up to /n/ digits).
-nnUpTo ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ) ⇒ s → Int → μ α
+nnUpTo ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ) ⇒ s → Int → μ α
 nnUpTo _ n | n <= 0 = empty
 nnUpTo s n = digit >>= go (n - 1) <?> systemName s ++ " digits"
   where go 0 !r = optional (PC.satisfy $ isDigitIn s) >>= \case
@@ -249,26 +251,26 @@ nnUpTo s n = digit >>= go (n - 1) <?> systemName s ++ " digits"
                     Nothing → return r
         radix   = radixIn s
         digit   = digitIn s
-{-# SPECIALIZE nnUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int #-}
-{-# SPECIALIZE nnUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int8 #-}
-{-# SPECIALIZE nnUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int16 #-}
-{-# SPECIALIZE nnUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int32 #-}
-{-# SPECIALIZE nnUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int64 #-}
-{-# SPECIALIZE nnUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word #-}
-{-# SPECIALIZE nnUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word8 #-}
-{-# SPECIALIZE nnUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word16 #-}
-{-# SPECIALIZE nnUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word32 #-}
-{-# SPECIALIZE nnUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word64 #-}
-{-# SPECIALIZE nnUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
-{-# SPECIALIZE nnUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
-{-# SPECIALIZE nnUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Decimal → Int → μ α #-}
-{-# SPECIALIZE nnUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
-{-# SPECIALIZE nnUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
-{-# SPECIALIZE nnUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
+{-# SPECIALIZE nnUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int #-}
+{-# SPECIALIZE nnUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int8 #-}
+{-# SPECIALIZE nnUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int16 #-}
+{-# SPECIALIZE nnUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int32 #-}
+{-# SPECIALIZE nnUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int64 #-}
+{-# SPECIALIZE nnUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word #-}
+{-# SPECIALIZE nnUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word8 #-}
+{-# SPECIALIZE nnUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word16 #-}
+{-# SPECIALIZE nnUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word32 #-}
+{-# SPECIALIZE nnUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word64 #-}
+{-# SPECIALIZE nnUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
+{-# SPECIALIZE nnUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
+{-# SPECIALIZE nnUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ α #-}
+{-# SPECIALIZE nnUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
+{-# SPECIALIZE nnUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
+{-# SPECIALIZE nnUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
 
 -- | Parse a non-negative number written in the specified positional
 --   numeral system (up to /n/ digits). Leading zeroes are not allowed.
-nncUpTo ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ) ⇒ s → Int → μ α
+nncUpTo ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ) ⇒ s → Int → μ α
 nncUpTo _ n | n <= 0 = empty
 nncUpTo s n = (<?> systemName s ++ " digits") $ digitIn s >>= \case
                 0 → optional (PC.satisfy $ isDigitIn s) >>= \case
@@ -283,27 +285,27 @@ nncUpTo s n = (<?> systemName s ++ " digits") $ digitIn s >>= \case
                     Nothing → return r
         radix   = radixIn s
         digit   = digitIn s
-{-# SPECIALIZE nncUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int #-}
-{-# SPECIALIZE nncUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int8 #-}
-{-# SPECIALIZE nncUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int16 #-}
-{-# SPECIALIZE nncUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int32 #-}
-{-# SPECIALIZE nncUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int64 #-}
-{-# SPECIALIZE nncUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word #-}
-{-# SPECIALIZE nncUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word8 #-}
-{-# SPECIALIZE nncUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word16 #-}
-{-# SPECIALIZE nncUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word32 #-}
-{-# SPECIALIZE nncUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word64 #-}
-{-# SPECIALIZE nncUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
-{-# SPECIALIZE nncUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
-{-# SPECIALIZE nncUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Decimal → Int → μ α #-}
-{-# SPECIALIZE nncUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
-{-# SPECIALIZE nncUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
-{-# SPECIALIZE nncUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
+{-# SPECIALIZE nncUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int #-}
+{-# SPECIALIZE nncUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int8 #-}
+{-# SPECIALIZE nncUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int16 #-}
+{-# SPECIALIZE nncUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int32 #-}
+{-# SPECIALIZE nncUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int64 #-}
+{-# SPECIALIZE nncUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word #-}
+{-# SPECIALIZE nncUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word8 #-}
+{-# SPECIALIZE nncUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word16 #-}
+{-# SPECIALIZE nncUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word32 #-}
+{-# SPECIALIZE nncUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word64 #-}
+{-# SPECIALIZE nncUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
+{-# SPECIALIZE nncUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
+{-# SPECIALIZE nncUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ α #-}
+{-# SPECIALIZE nncUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
+{-# SPECIALIZE nncUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
+{-# SPECIALIZE nncUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
 
 -- | Parse a non-negative number written in the specified positional
 --   numeral system, failing on overflow.
 nnBounded ∷ (PositionalSystem s, Ord α, Bounded α, Integral α,
-             Monad μ, CharParsing μ) ⇒ s → μ α
+             MonadFail μ, CharParsing μ) ⇒ s → μ α
 nnBounded s = digit >>= go <?> systemName s ++ " digits"
   where (q, r) = quotRem maxBound radix
         go !n  = optional digit >>= \case
@@ -313,27 +315,27 @@ nnBounded s = digit >>= go <?> systemName s ++ " digits"
                    Nothing → return n
         radix  = radixIn s
         digit  = digitIn s
-{-# SPECIALIZE nnBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int #-}
-{-# SPECIALIZE nnBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
-{-# SPECIALIZE nnBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
-{-# SPECIALIZE nnBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
-{-# SPECIALIZE nnBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
-{-# SPECIALIZE nnBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word #-}
-{-# SPECIALIZE nnBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
-{-# SPECIALIZE nnBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
-{-# SPECIALIZE nnBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
-{-# SPECIALIZE nnBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
-{-# SPECIALIZE nnBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE nnBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE nnBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Decimal → μ α #-}
-{-# SPECIALIZE nnBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE nnBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE nnBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE nnBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int #-}
+{-# SPECIALIZE nnBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
+{-# SPECIALIZE nnBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
+{-# SPECIALIZE nnBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
+{-# SPECIALIZE nnBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
+{-# SPECIALIZE nnBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word #-}
+{-# SPECIALIZE nnBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
+{-# SPECIALIZE nnBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
+{-# SPECIALIZE nnBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
+{-# SPECIALIZE nnBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
+{-# SPECIALIZE nnBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE nnBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE nnBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Decimal → μ α #-}
+{-# SPECIALIZE nnBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE nnBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE nnBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-negative number written in the specified positional
 --   numeral system, failing on overflow. Leading zeroes are not allowed.
 nncBounded ∷ (PositionalSystem s, Ord α, Bounded α, Integral α,
-              Monad μ, CharParsing μ) ⇒ s → μ α
+              MonadFail μ, CharParsing μ) ⇒ s → μ α
 nncBounded s = (<?> systemName s ++ " digits") $ digit >>= \case
                  0 → optional (PC.satisfy $ isDigitIn s) >>= \case
                        Just _  → PC.unexpected "leading zero"
@@ -347,91 +349,91 @@ nncBounded s = (<?> systemName s ++ " digits") $ digit >>= \case
                    Nothing → return n
         radix  = radixIn s
         digit  = digitIn s
-{-# SPECIALIZE nncBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int #-}
-{-# SPECIALIZE nncBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
-{-# SPECIALIZE nncBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
-{-# SPECIALIZE nncBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
-{-# SPECIALIZE nncBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
-{-# SPECIALIZE nncBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word #-}
-{-# SPECIALIZE nncBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
-{-# SPECIALIZE nncBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
-{-# SPECIALIZE nncBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
-{-# SPECIALIZE nncBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
-{-# SPECIALIZE nncBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE nncBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE nncBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Decimal → μ α #-}
-{-# SPECIALIZE nncBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE nncBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE nncBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE nncBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int #-}
+{-# SPECIALIZE nncBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
+{-# SPECIALIZE nncBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
+{-# SPECIALIZE nncBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
+{-# SPECIALIZE nncBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
+{-# SPECIALIZE nncBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word #-}
+{-# SPECIALIZE nncBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
+{-# SPECIALIZE nncBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
+{-# SPECIALIZE nncBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
+{-# SPECIALIZE nncBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
+{-# SPECIALIZE nncBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE nncBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE nncBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Decimal → μ α #-}
+{-# SPECIALIZE nncBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE nncBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE nncBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-negative binary number written in the specified
 --   positional numeral system.
-nnBits ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ) ⇒ s → μ α
+nnBits ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ s → μ α
 nnBits s = digit >>= go <?> systemName s ++ " digits"
   where go !r     = optional digit >>= \case
                       Just d  → go ((r `shiftL` digitBits) .|. d)
                       Nothing → return r
         digitBits = digitBitsIn s
         digit     = digitIn s
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
-{-# SPECIALIZE nnBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
-{-# SPECIALIZE nnBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE nnBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE nnBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE nnBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE nnBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
+{-# SPECIALIZE nnBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
+{-# SPECIALIZE nnBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE nnBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE nnBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE nnBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE nnBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-negative binary number written in the specified
 --   positional numeral system. Leading zeroes are not allowed.
-nncBits ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ) ⇒ s → μ α
+nncBits ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ s → μ α
 nncBits s = (<?> systemName s ++ " digits") $ digit >>= \case
               0 → optional (PC.satisfy $ isDigitIn s) >>= \case
                     Just _  → PC.unexpected "leading zero"
@@ -442,65 +444,65 @@ nncBits s = (<?> systemName s ++ " digits") $ digit >>= \case
                       Nothing → return r
         digitBits = digitBitsIn s
         digit     = digitIn s
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
-{-# SPECIALIZE nncBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
-{-# SPECIALIZE nncBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE nncBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE nncBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE nncBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE nncBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
+{-# SPECIALIZE nncBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
+{-# SPECIALIZE nncBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE nncBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE nncBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE nncBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE nncBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-negative binary number written in the specified
 --   positional numeral system (up to /n/ digits).
-nnBitsUpTo ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ)
+nnBitsUpTo ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ)
            ⇒ s → Int → μ α
 nnBitsUpTo _ n | n <= 0 = empty
 nnBitsUpTo s n = digit >>= go (n - 1) <?> systemName s ++ " digits"
@@ -512,66 +514,66 @@ nnBitsUpTo s n = digit >>= go (n - 1) <?> systemName s ++ " digits"
                       Nothing → return r
         digitBits = digitBitsIn s
         digit     = digitIn s
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int8 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int16 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int32 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int64 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word8 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word16 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word32 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word64 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int8 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int16 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int32 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int64 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word8 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word16 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word32 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word64 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int8 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int16 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int32 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int64 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word8 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word16 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word32 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word64 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int8 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int16 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int32 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int64 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word8 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word16 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word32 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word64 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int8 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int16 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int32 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int64 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word8 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word16 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word32 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word64 #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
-{-# SPECIALIZE nnBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int8 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int16 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int32 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int64 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word8 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word16 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word32 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word64 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int8 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int16 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int32 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int64 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word8 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word16 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word32 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word64 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int8 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int16 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int32 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int64 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word8 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word16 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word32 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word64 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int8 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int16 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int32 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int64 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word8 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word16 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word32 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word64 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int8 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int16 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int32 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int64 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word8 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word16 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word32 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word64 #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
+{-# SPECIALIZE nnBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
 
 -- | Parse a non-negative binary number written in the specified
 --   positional numeral system (up to /n/ digits). Leading zeroes are not
 --   allowed.
-nncBitsUpTo ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ)
+nncBitsUpTo ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ)
             ⇒ s → Int → μ α
 nncBitsUpTo _ n | n <= 0 = empty
 nncBitsUpTo s n = (<?> systemName s ++ " digits") $ digitIn s >>= \case
@@ -587,66 +589,66 @@ nncBitsUpTo s n = (<?> systemName s ++ " digits") $ digitIn s >>= \case
                       Nothing → return r
         digitBits = digitBitsIn s
         digit     = digitIn s
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int8 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int16 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int32 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int64 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word8 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word16 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word32 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word64 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int8 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int16 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int32 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int64 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word8 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word16 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word32 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word64 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int8 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int16 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int32 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int64 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word8 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word16 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word32 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word64 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int8 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int16 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int32 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int64 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word8 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word16 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word32 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word64 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int8 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int16 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int32 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int64 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word8 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word16 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word32 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word64 #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
-{-# SPECIALIZE nncBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int8 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int16 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int32 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int64 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word8 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word16 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word32 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word64 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int8 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int16 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int32 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int64 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word8 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word16 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word32 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word64 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int8 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int16 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int32 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int64 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word8 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word16 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word32 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word64 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int8 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int16 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int32 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int64 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word8 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word16 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word32 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word64 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int8 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int16 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int32 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int64 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word8 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word16 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word32 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word64 #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
+{-# SPECIALIZE nncBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
 
 -- | Parse a non-negative binary number written in the specified
 --   positional numeral system, failing on overflow.
 nnbBits ∷ (BitSystem s, Ord α, Bounded α, Num α, Bits α,
-           Monad μ, CharParsing μ)
+           MonadFail μ, CharParsing μ)
         ⇒ s → μ α
 nnbBits s = digit >>= go <?> systemName s ++ " digits"
   where q = maxBound `shiftR` digitBits
@@ -658,67 +660,67 @@ nnbBits s = digit >>= go <?> systemName s ++ " digits"
                   Nothing → return n
         digitBits = digitBitsIn s
         digit     = digitIn s
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
-{-# SPECIALIZE nnbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
-{-# SPECIALIZE nnbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE nnbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE nnbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE nnbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE nnbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
+{-# SPECIALIZE nnbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
+{-# SPECIALIZE nnbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE nnbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE nnbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE nnbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE nnbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-negative binary number written in the specified
 --   positional numeral system, failing on overflow. Leading zeroes are not
 --   allowed.
 nncbBits ∷ (BitSystem s, Ord α, Bounded α, Num α, Bits α,
-            Monad μ, CharParsing μ)
+            MonadFail μ, CharParsing μ)
          ⇒ s → μ α
 nncbBits s = (<?> systemName s ++ " digits") $ digitIn s >>= \case
                0 → optional (PC.satisfy $ isDigitIn s) >>= \case
@@ -734,66 +736,66 @@ nncbBits s = (<?> systemName s ++ " digits") $ digitIn s >>= \case
                   Nothing → return n
         digitBits = digitBitsIn s
         digit     = digitIn s
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
-{-# SPECIALIZE nncbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
-{-# SPECIALIZE nncbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE nncbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE nncbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE nncbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE nncbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
+{-# SPECIALIZE nncbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
+{-# SPECIALIZE nncbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE nncbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE nncbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE nncbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE nncbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-positive number written in the specified positional
 --   numeral system. For example, parsing \"123\" as a decimal would produce
 --   /-123/, not /123/.
-nonPositive ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ) ⇒ s → μ α
+nonPositive ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ) ⇒ s → μ α
 nonPositive s = (<?> systemName s ++ " digits") $ do
                   r ← digitIn s
                   go $ fromIntegral $ negate (r ∷ Int)
@@ -802,26 +804,26 @@ nonPositive s = (<?> systemName s ++ " digits") $ do
                   Nothing → return r
         radix = radixIn s
         digit = digitIn s
-{-# SPECIALIZE nonPositive ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int #-}
-{-# SPECIALIZE nonPositive ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
-{-# SPECIALIZE nonPositive ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
-{-# SPECIALIZE nonPositive ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
-{-# SPECIALIZE nonPositive ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
-{-# SPECIALIZE nonPositive ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word #-}
-{-# SPECIALIZE nonPositive ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
-{-# SPECIALIZE nonPositive ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
-{-# SPECIALIZE nonPositive ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
-{-# SPECIALIZE nonPositive ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
-{-# SPECIALIZE nonPositive ∷ (Num α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE nonPositive ∷ (Num α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE nonPositive ∷ (Num α, Monad μ, CharParsing μ) ⇒ Decimal → μ α #-}
-{-# SPECIALIZE nonPositive ∷ (Num α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE nonPositive ∷ (Num α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE nonPositive ∷ (Num α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE nonPositive ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int #-}
+{-# SPECIALIZE nonPositive ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
+{-# SPECIALIZE nonPositive ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
+{-# SPECIALIZE nonPositive ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
+{-# SPECIALIZE nonPositive ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
+{-# SPECIALIZE nonPositive ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word #-}
+{-# SPECIALIZE nonPositive ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
+{-# SPECIALIZE nonPositive ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
+{-# SPECIALIZE nonPositive ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
+{-# SPECIALIZE nonPositive ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
+{-# SPECIALIZE nonPositive ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE nonPositive ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE nonPositive ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Decimal → μ α #-}
+{-# SPECIALIZE nonPositive ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE nonPositive ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE nonPositive ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-positive number written in the specified positional
 --   numeral system. Leading zeroes are not allowed.
-npCompact ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ) ⇒ s → μ α
+npCompact ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ) ⇒ s → μ α
 npCompact s = (<?> systemName s ++ " digits") $ digitIn s >>= \case
                 0 → optional (PC.satisfy $ isDigitIn s) >>= \case
                       Just _  → PC.unexpected "leading zero"
@@ -832,26 +834,26 @@ npCompact s = (<?> systemName s ++ " digits") $ digitIn s >>= \case
                   Nothing → return r
         radix = radixIn s
         digit = digitIn s
-{-# SPECIALIZE npCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int #-}
-{-# SPECIALIZE npCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
-{-# SPECIALIZE npCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
-{-# SPECIALIZE npCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
-{-# SPECIALIZE npCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
-{-# SPECIALIZE npCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word #-}
-{-# SPECIALIZE npCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
-{-# SPECIALIZE npCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
-{-# SPECIALIZE npCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
-{-# SPECIALIZE npCompact ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
-{-# SPECIALIZE npCompact ∷ (Num α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE npCompact ∷ (Num α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE npCompact ∷ (Num α, Monad μ, CharParsing μ) ⇒ Decimal → μ α #-}
-{-# SPECIALIZE npCompact ∷ (Num α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE npCompact ∷ (Num α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE npCompact ∷ (Num α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE npCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int #-}
+{-# SPECIALIZE npCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
+{-# SPECIALIZE npCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
+{-# SPECIALIZE npCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
+{-# SPECIALIZE npCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
+{-# SPECIALIZE npCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word #-}
+{-# SPECIALIZE npCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
+{-# SPECIALIZE npCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
+{-# SPECIALIZE npCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
+{-# SPECIALIZE npCompact ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
+{-# SPECIALIZE npCompact ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE npCompact ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE npCompact ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Decimal → μ α #-}
+{-# SPECIALIZE npCompact ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE npCompact ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE npCompact ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-positive number written in the specified positional
 --   numeral system (up to /n/ digits).
-npUpTo ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ) ⇒ s → Int → μ α
+npUpTo ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ) ⇒ s → Int → μ α
 npUpTo _ n | n <= 0 = empty
 npUpTo s n = (<?> systemName s ++ " digits") $ do
                r ← digitIn s
@@ -864,26 +866,26 @@ npUpTo s n = (<?> systemName s ++ " digits") $ do
                     Nothing → return r
         radix   = radixIn s
         digit   = digitIn s
-{-# SPECIALIZE npUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int #-}
-{-# SPECIALIZE npUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int8 #-}
-{-# SPECIALIZE npUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int16 #-}
-{-# SPECIALIZE npUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int32 #-}
-{-# SPECIALIZE npUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int64 #-}
-{-# SPECIALIZE npUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word #-}
-{-# SPECIALIZE npUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word8 #-}
-{-# SPECIALIZE npUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word16 #-}
-{-# SPECIALIZE npUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word32 #-}
-{-# SPECIALIZE npUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word64 #-}
-{-# SPECIALIZE npUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
-{-# SPECIALIZE npUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
-{-# SPECIALIZE npUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Decimal → Int → μ α #-}
-{-# SPECIALIZE npUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
-{-# SPECIALIZE npUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
-{-# SPECIALIZE npUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
+{-# SPECIALIZE npUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int #-}
+{-# SPECIALIZE npUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int8 #-}
+{-# SPECIALIZE npUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int16 #-}
+{-# SPECIALIZE npUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int32 #-}
+{-# SPECIALIZE npUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int64 #-}
+{-# SPECIALIZE npUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word #-}
+{-# SPECIALIZE npUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word8 #-}
+{-# SPECIALIZE npUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word16 #-}
+{-# SPECIALIZE npUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word32 #-}
+{-# SPECIALIZE npUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word64 #-}
+{-# SPECIALIZE npUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
+{-# SPECIALIZE npUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
+{-# SPECIALIZE npUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ α #-}
+{-# SPECIALIZE npUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
+{-# SPECIALIZE npUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
+{-# SPECIALIZE npUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
 
 -- | Parse a non-positive number written in the specified positional
 --   numeral system (up to /n/ digits). Leading zeroes are not allowed.
-npcUpTo ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ) ⇒ s → Int → μ α
+npcUpTo ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ) ⇒ s → Int → μ α
 npcUpTo _ n | n <= 0 = empty
 npcUpTo s n = (<?> systemName s ++ " digits") $ digitIn s >>= \case
                 0 → optional (PC.satisfy $ isDigitIn s) >>= \case
@@ -898,27 +900,27 @@ npcUpTo s n = (<?> systemName s ++ " digits") $ digitIn s >>= \case
                     Nothing → return r
         radix   = radixIn s
         digit   = digitIn s
-{-# SPECIALIZE npcUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int #-}
-{-# SPECIALIZE npcUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int8 #-}
-{-# SPECIALIZE npcUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int16 #-}
-{-# SPECIALIZE npcUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int32 #-}
-{-# SPECIALIZE npcUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Int64 #-}
-{-# SPECIALIZE npcUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word #-}
-{-# SPECIALIZE npcUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word8 #-}
-{-# SPECIALIZE npcUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word16 #-}
-{-# SPECIALIZE npcUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word32 #-}
-{-# SPECIALIZE npcUpTo ∷ (Monad μ, CharParsing μ) ⇒ Decimal → Int → μ Word64 #-}
-{-# SPECIALIZE npcUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
-{-# SPECIALIZE npcUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
-{-# SPECIALIZE npcUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Decimal → Int → μ α #-}
-{-# SPECIALIZE npcUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
-{-# SPECIALIZE npcUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
-{-# SPECIALIZE npcUpTo ∷ (Num α, Monad μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
+{-# SPECIALIZE npcUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int #-}
+{-# SPECIALIZE npcUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int8 #-}
+{-# SPECIALIZE npcUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int16 #-}
+{-# SPECIALIZE npcUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int32 #-}
+{-# SPECIALIZE npcUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Int64 #-}
+{-# SPECIALIZE npcUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word #-}
+{-# SPECIALIZE npcUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word8 #-}
+{-# SPECIALIZE npcUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word16 #-}
+{-# SPECIALIZE npcUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word32 #-}
+{-# SPECIALIZE npcUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ Word64 #-}
+{-# SPECIALIZE npcUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
+{-# SPECIALIZE npcUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
+{-# SPECIALIZE npcUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Decimal → Int → μ α #-}
+{-# SPECIALIZE npcUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
+{-# SPECIALIZE npcUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
+{-# SPECIALIZE npcUpTo ∷ (Num α, MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
 
 -- | Parse a non-positive number written in the specified positional
 --   numeral system, failing on overflow.
 npBounded ∷ (PositionalSystem s, Ord α, Bounded α, Integral α,
-             Monad μ, CharParsing μ)
+             MonadFail μ, CharParsing μ)
           ⇒ s → μ α
 npBounded s = (<?> systemName s ++ " digits") $ do
                 n ← digitIn s
@@ -932,27 +934,27 @@ npBounded s = (<?> systemName s ++ " digits") $ do
                     Nothing → return n
         radix   = radixIn s
         digit   = digitIn s
-{-# SPECIALIZE npBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int #-}
-{-# SPECIALIZE npBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
-{-# SPECIALIZE npBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
-{-# SPECIALIZE npBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
-{-# SPECIALIZE npBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
-{-# SPECIALIZE npBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word #-}
-{-# SPECIALIZE npBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
-{-# SPECIALIZE npBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
-{-# SPECIALIZE npBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
-{-# SPECIALIZE npBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
-{-# SPECIALIZE npBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE npBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE npBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Decimal → μ α #-}
-{-# SPECIALIZE npBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE npBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE npBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE npBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int #-}
+{-# SPECIALIZE npBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
+{-# SPECIALIZE npBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
+{-# SPECIALIZE npBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
+{-# SPECIALIZE npBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
+{-# SPECIALIZE npBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word #-}
+{-# SPECIALIZE npBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
+{-# SPECIALIZE npBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
+{-# SPECIALIZE npBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
+{-# SPECIALIZE npBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
+{-# SPECIALIZE npBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE npBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE npBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Decimal → μ α #-}
+{-# SPECIALIZE npBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE npBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE npBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-positive number written in the specified positional
 --   numeral system, failing on overflow. Leading zeroes are not allowed.
 npcBounded ∷ (PositionalSystem s, Ord α, Bounded α, Integral α,
-              Monad μ, CharParsing μ)
+              MonadFail μ, CharParsing μ)
            ⇒ s → μ α
 npcBounded s = (<?> systemName s ++ " digits") $ digitIn s >>= \case
                  0 → optional (PC.satisfy $ isDigitIn s) >>= \case
@@ -968,26 +970,26 @@ npcBounded s = (<?> systemName s ++ " digits") $ digitIn s >>= \case
                     Nothing → return n
         radix   = radixIn s
         digit   = digitIn s
-{-# SPECIALIZE npcBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int #-}
-{-# SPECIALIZE npcBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
-{-# SPECIALIZE npcBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
-{-# SPECIALIZE npcBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
-{-# SPECIALIZE npcBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
-{-# SPECIALIZE npcBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word #-}
-{-# SPECIALIZE npcBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
-{-# SPECIALIZE npcBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
-{-# SPECIALIZE npcBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
-{-# SPECIALIZE npcBounded ∷ (Monad μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
-{-# SPECIALIZE npcBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE npcBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE npcBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Decimal → μ α #-}
-{-# SPECIALIZE npcBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE npcBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE npcBounded ∷ (Bounded α, Integral α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE npcBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int #-}
+{-# SPECIALIZE npcBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int8 #-}
+{-# SPECIALIZE npcBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int16 #-}
+{-# SPECIALIZE npcBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int32 #-}
+{-# SPECIALIZE npcBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Int64 #-}
+{-# SPECIALIZE npcBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word #-}
+{-# SPECIALIZE npcBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word8 #-}
+{-# SPECIALIZE npcBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word16 #-}
+{-# SPECIALIZE npcBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word32 #-}
+{-# SPECIALIZE npcBounded ∷ (MonadFail μ, CharParsing μ) ⇒ Decimal → μ Word64 #-}
+{-# SPECIALIZE npcBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE npcBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE npcBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Decimal → μ α #-}
+{-# SPECIALIZE npcBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE npcBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE npcBounded ∷ (Bounded α, Integral α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-positive two\'s complement binary number written in
 --   the specified positional numeral system.
-npBits ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ) ⇒ s → μ α
+npBits ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ s → μ α
 npBits s = (<?> systemName s ++ " digits") $ do
              r ← digit
              go $ fromIntegral $ negate (r ∷ Int)
@@ -997,65 +999,65 @@ npBits s = (<?> systemName s ++ " digits") $ do
                       Nothing → return r
         digitBits = digitBitsIn s
         digit     = digitIn s
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
-{-# SPECIALIZE npBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
-{-# SPECIALIZE npBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE npBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE npBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE npBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE npBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
+{-# SPECIALIZE npBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
+{-# SPECIALIZE npBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE npBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE npBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE npBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE npBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-positive two\'s complement binary number written in
 --   the specified positional numeral system (up to /n/ digits).
-npBitsUpTo ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ)
+npBitsUpTo ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ)
            ⇒ s → Int → μ α
 npBitsUpTo _ n | n <= 0 = empty
 npBitsUpTo s n = (<?> systemName s ++ " digits") $ do
@@ -1070,65 +1072,65 @@ npBitsUpTo s n = (<?> systemName s ++ " digits") $ do
                       Nothing → return r
         digitBits = digitBitsIn s
         digit     = digitIn s
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int8 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int16 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int32 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int64 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word8 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word16 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word32 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word64 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int8 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int16 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int32 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int64 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word8 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word16 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word32 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word64 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int8 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int16 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int32 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int64 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word8 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word16 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word32 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word64 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int8 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int16 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int32 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int64 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word8 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word16 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word32 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word64 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int8 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int16 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int32 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int64 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word8 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word16 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word32 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word64 #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
-{-# SPECIALIZE npBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int8 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int16 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int32 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int64 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word8 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word16 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word32 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word64 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int8 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int16 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int32 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int64 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word8 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word16 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word32 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word64 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int8 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int16 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int32 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int64 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word8 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word16 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word32 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word64 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int8 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int16 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int32 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int64 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word8 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word16 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word32 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word64 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int8 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int16 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int32 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int64 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word8 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word16 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word32 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word64 #-}
+{-# SPECIALIZE npBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
+{-# SPECIALIZE npBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
+{-# SPECIALIZE npBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
+{-# SPECIALIZE npBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
+{-# SPECIALIZE npBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
 
 -- | Parse a non-positive two\'s complement binary number written in
 --   the specified positional numeral system. Leading zeroes are not allowed.
-npcBits ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ) ⇒ s → μ α
+npcBits ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ s → μ α
 npcBits s = (<?> systemName s ++ " digits") $ digit >>= \case
               0 → optional (PC.satisfy $ isDigitIn s) >>= \case
                     Just _  → PC.unexpected "leading zero"
@@ -1140,66 +1142,66 @@ npcBits s = (<?> systemName s ++ " digits") $ digit >>= \case
                       Nothing → return r
         digitBits = digitBitsIn s
         digit     = digitIn s
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
-{-# SPECIALIZE npcBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
-{-# SPECIALIZE npcBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE npcBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE npcBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE npcBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE npcBits ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
+{-# SPECIALIZE npcBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
+{-# SPECIALIZE npcBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE npcBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE npcBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE npcBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE npcBits ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-positive two\'s complement binary number written in
 --   the specified positional numeral system (up to /n/ digits).
 --   Leading zeroes are not allowed.
-npcBitsUpTo ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ)
+npcBitsUpTo ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ)
             ⇒ s → Int → μ α
 npcBitsUpTo _ n | n <= 0 = empty
 npcBitsUpTo s n = (<?> systemName s ++ " digits") $ digit >>= \case
@@ -1216,67 +1218,67 @@ npcBitsUpTo s n = (<?> systemName s ++ " digits") $ digit >>= \case
                       Nothing → return r
         digitBits = digitBitsIn s
         digit     = digitIn s
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int8 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int16 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int32 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Int64 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word8 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word16 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word32 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Binary → Int → μ Word64 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int8 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int16 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int32 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Int64 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word8 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word16 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word32 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Octal → Int → μ Word64 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int8 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int16 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int32 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int64 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word8 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word16 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word32 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word64 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int8 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int16 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int32 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Int64 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word8 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word16 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word32 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ LowHex → Int → μ Word64 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int8 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int16 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int32 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Int64 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word8 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word16 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word32 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Monad μ, CharParsing μ) ⇒ UpHex → Int → μ Word64 #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
-{-# SPECIALIZE npcBitsUpTo ∷ (Num α, Bits α, Monad μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int8 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int16 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int32 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Int64 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word8 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word16 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word32 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ Word64 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int8 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int16 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int32 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Int64 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word8 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word16 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word32 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ Word64 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int8 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int16 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int32 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Int64 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word8 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word16 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word32 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ Word64 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int8 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int16 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int32 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Int64 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word8 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word16 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word32 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ Word64 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int8 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int16 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int32 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Int64 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word8 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word16 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word32 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ Word64 #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Binary → Int → μ α #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Octal → Int → μ α #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → Int → μ α #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ LowHex → Int → μ α #-}
+{-# SPECIALIZE npcBitsUpTo ∷ (Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ UpHex → Int → μ α #-}
 
 -- | Parse a non-positive two\'s complement binary number written in
 --   the specified positional numeral system, failing on overflow.
 npbBits ∷ ∀ s μ α
         . (BitSystem s, Ord α, Bounded α, Num α, Bits α,
-           Monad μ, CharParsing μ)
+           MonadFail μ, CharParsing μ)
         ⇒ s → μ α
 npbBits s = (<?> systemName s ++ " digits") $ do
               n ← digit
@@ -1292,68 +1294,68 @@ npbBits s = (<?> systemName s ++ " digits") $ do
                       Nothing → return n
         digitBits = digitBitsIn s
         digit     = digitIn s
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
-{-# SPECIALIZE npbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
-{-# SPECIALIZE npbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE npbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE npbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE npbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE npbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
+{-# SPECIALIZE npbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
+{-# SPECIALIZE npbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE npbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE npbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE npbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE npbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Parse a non-positive two\'s complement binary number written in
 --   the specified positional numeral system, failing on overflow.
 --   Leading zeroes are not allowed.
 npcbBits ∷ ∀ s μ α
          . (BitSystem s, Ord α, Bounded α, Num α, Bits α,
-            Monad μ, CharParsing μ)
+            MonadFail μ, CharParsing μ)
         ⇒ s → μ α
 npcbBits s = (<?> systemName s ++ " digits") $ digit >>= \case
                0 → optional (PC.satisfy $ isDigitIn s) >>= \case
@@ -1371,61 +1373,61 @@ npcbBits s = (<?> systemName s ++ " digits") $ digit >>= \case
                       Nothing → return n
         digitBits = digitBitsIn s
         digit     = digitIn s
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
-{-# SPECIALIZE npcbBits ∷ (Monad μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
-{-# SPECIALIZE npcbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ Binary → μ α #-}
-{-# SPECIALIZE npcbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ Octal → μ α #-}
-{-# SPECIALIZE npcbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
-{-# SPECIALIZE npcbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ LowHex → μ α #-}
-{-# SPECIALIZE npcbBits ∷ (Ord α, Bounded α, Num α, Bits α, Monad μ, CharParsing μ) ⇒ UpHex → μ α #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int8 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int16 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int32 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Int64 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word8 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word16 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word32 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Binary → μ Word64 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int8 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int16 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int32 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Int64 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word8 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word16 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word32 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Octal → μ Word64 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int8 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int16 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int32 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Int64 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word8 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word16 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word32 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ Word64 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int8 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int16 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int32 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Int64 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word8 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word16 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word32 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ LowHex → μ Word64 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int8 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int16 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int32 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Int64 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word8 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word16 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word32 #-}
+{-# SPECIALIZE npcbBits ∷ (MonadFail μ, CharParsing μ) ⇒ UpHex → μ Word64 #-}
+{-# SPECIALIZE npcbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Binary → μ α #-}
+{-# SPECIALIZE npcbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Octal → μ α #-}
+{-# SPECIALIZE npcbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ Hexadecimal → μ α #-}
+{-# SPECIALIZE npcbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ LowHex → μ α #-}
+{-# SPECIALIZE npcbBits ∷ (Ord α, Bounded α, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ UpHex → μ α #-}
 
 -- | Sign of a number.
 data Sign = NonNegative | NonPositive
@@ -1453,7 +1455,7 @@ optSign  =  (pure NonPositive <* PC.char '-')
 
 -- | Parse a number written in the specified positional numeral system.
 --   The supplied parser is used to determine the sign of the number.
-number' ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ)
+number' ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ)
         ⇒ μ Sign → s → μ α
 number' neg s = (<?> systemName s) $ neg >>= \case
   NonNegative → nonNegative s
@@ -1461,14 +1463,14 @@ number' neg s = (<?> systemName s) $ neg >>= \case
 {-# INLINE number' #-}
 
 -- | A shorthand for 'number'' 'optMinus'.
-number ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ) ⇒ s → μ α
+number ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ) ⇒ s → μ α
 number = number' optMinus
 {-# INLINE number #-}
 
 -- | Parse a number written in the specified positional numeral system.
 --   The supplied parser is used to determine the sign of the number.
 --   Leading zeroes are not allowed.
-compact' ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ)
+compact' ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ)
          ⇒ μ Sign → s → μ α
 compact' neg s = (<?> systemName s) $ neg >>= \case
   NonNegative → nnCompact s
@@ -1476,14 +1478,14 @@ compact' neg s = (<?> systemName s) $ neg >>= \case
 {-# INLINE compact' #-}
 
 -- | A shorthand for 'compact'' 'optMinus'.
-compact ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ) ⇒ s → μ α
+compact ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ) ⇒ s → μ α
 compact = compact' optMinus
 {-# INLINE compact #-}
 
 -- | Parse a number written in the specified positional numeral system
 --   (up to /n/ digits). The supplied parser is used to determine the sign of
 --   the number.
-numberUpTo' ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ)
+numberUpTo' ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ)
             ⇒ μ Sign → s → Int → μ α
 numberUpTo' neg s n = (<?> systemName s) $ neg >>= \case
   NonNegative → nnUpTo s n
@@ -1491,7 +1493,7 @@ numberUpTo' neg s n = (<?> systemName s) $ neg >>= \case
 {-# INLINE numberUpTo' #-}
 
 -- | A shorthand for 'numberUpTo'' 'optMinus'.
-numberUpTo ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ)
+numberUpTo ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ)
            ⇒ s → Int → μ α
 numberUpTo = numberUpTo' optMinus
 {-# INLINE numberUpTo #-}
@@ -1499,7 +1501,7 @@ numberUpTo = numberUpTo' optMinus
 -- | Parse a number written in the specified positional numeral system
 --   (up to /n/ digits). The supplied parser is used to determine the sign of
 --   the number. Leading zeroes are not allowed.
-compactUpTo' ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ)
+compactUpTo' ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ)
              ⇒ μ Sign → s → Int → μ α
 compactUpTo' neg s n = (<?> systemName s) $ neg >>= \case
   NonNegative → nncUpTo s n
@@ -1507,7 +1509,7 @@ compactUpTo' neg s n = (<?> systemName s) $ neg >>= \case
 {-# INLINE compactUpTo' #-}
 
 -- | A shorthand for 'compactUpTo'' 'optMinus'.
-compactUpTo ∷ (PositionalSystem s, Num α, Monad μ, CharParsing μ)
+compactUpTo ∷ (PositionalSystem s, Num α, MonadFail μ, CharParsing μ)
            ⇒ s → Int → μ α
 compactUpTo = compactUpTo' optMinus
 {-# INLINE compactUpTo #-}
@@ -1516,7 +1518,7 @@ compactUpTo = compactUpTo' optMinus
 --   failing on overflow. The supplied parser is used to determine the sign
 --   of the number.
 bounded' ∷ (PositionalSystem s, Ord α, Bounded α, Integral α,
-            Monad μ, CharParsing μ)
+            MonadFail μ, CharParsing μ)
          ⇒ μ Sign → s → μ α
 bounded' neg s = (<?> systemName s) $ neg >>= \case
   NonNegative → nnBounded s
@@ -1525,7 +1527,7 @@ bounded' neg s = (<?> systemName s) $ neg >>= \case
 
 -- | A shorthand for 'bounded'' 'optMinus'.
 bounded ∷ (PositionalSystem s, Ord α, Bounded α, Integral α,
-           Monad μ, CharParsing μ) ⇒ s → μ α
+           MonadFail μ, CharParsing μ) ⇒ s → μ α
 bounded = bounded' optMinus
 {-# INLINE bounded #-}
 
@@ -1533,7 +1535,7 @@ bounded = bounded' optMinus
 --   failing on overflow. The supplied parser is used to determine the sign
 --   of the number. Leading zeroes are not allowed.
 cBounded' ∷ (PositionalSystem s, Ord α, Bounded α, Integral α,
-             Monad μ, CharParsing μ)
+             MonadFail μ, CharParsing μ)
           ⇒ μ Sign → s → μ α
 cBounded' neg s = (<?> systemName s) $ neg >>= \case
   NonNegative → nncBounded s
@@ -1542,14 +1544,14 @@ cBounded' neg s = (<?> systemName s) $ neg >>= \case
 
 -- | A shorthand for 'cBounded'' 'optMinus'.
 cBounded ∷ (PositionalSystem s, Ord α, Bounded α, Integral α,
-            Monad μ, CharParsing μ) ⇒ s → μ α
+            MonadFail μ, CharParsing μ) ⇒ s → μ α
 cBounded = cBounded' optMinus
 {-# INLINE cBounded #-}
 
 -- | Parse a (two\'s complement) binary number written in the specified
 --   positional numeral system. The supplied parser is used to determine
 --   the sign of the number.
-bits' ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ)
+bits' ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ)
       ⇒ μ Sign → s → μ α
 bits' neg s = (<?> systemName s) $ neg >>= \case
   NonNegative → nnBits s
@@ -1557,14 +1559,14 @@ bits' neg s = (<?> systemName s) $ neg >>= \case
 {-# INLINE bits' #-}
 
 -- | A shorthand for 'bits'' 'optMinus'.
-bits ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ) ⇒ s → μ α
+bits ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ s → μ α
 bits = bits' optMinus
 {-# INLINE bits #-}
 
 -- | Parse a (two\'s complement) binary number written in the specified
 --   positional numeral system. The supplied parser is used to determine
 --   the sign of the number. Leading zeroes are not allowed.
-cBits' ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ)
+cBits' ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ)
        ⇒ μ Sign → s → μ α
 cBits' neg s = (<?> systemName s) $ neg >>= \case
   NonNegative → nncBits s
@@ -1572,14 +1574,14 @@ cBits' neg s = (<?> systemName s) $ neg >>= \case
 {-# INLINE cBits' #-}
 
 -- | A shorthand for 'cBits'' 'optMinus'.
-cBits ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ) ⇒ s → μ α
+cBits ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ) ⇒ s → μ α
 cBits = cBits' optMinus
 {-# INLINE cBits #-}
 
 -- | Parse a (two\'s complement) binary number written in the specified
 --   positional numeral system (up to /n/ digits). The supplied parser is
 --   used to determine the sign of the number.
-bitsUpTo' ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ)
+bitsUpTo' ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ)
           ⇒ μ Sign → s → Int → μ α
 bitsUpTo' neg s n = (<?> systemName s) $ neg >>= \case
   NonNegative → nnBitsUpTo s n
@@ -1587,7 +1589,7 @@ bitsUpTo' neg s n = (<?> systemName s) $ neg >>= \case
 {-# INLINE bitsUpTo' #-}
 
 -- | A shorthand for 'bitsUpTo'' 'optMinus'.
-bitsUpTo ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ)
+bitsUpTo ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ)
          ⇒ s → Int → μ α
 bitsUpTo = bitsUpTo' optMinus
 {-# INLINE bitsUpTo #-}
@@ -1596,7 +1598,7 @@ bitsUpTo = bitsUpTo' optMinus
 --   positional numeral system (up to /n/ digits). The supplied parser is
 --   used to determine the sign of the number. Leading zeroes are not
 --   allowed.
-cBitsUpTo' ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ)
+cBitsUpTo' ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ)
            ⇒ μ Sign → s → Int → μ α
 cBitsUpTo' neg s n = (<?> systemName s) $ neg >>= \case
   NonNegative → nncBitsUpTo s n
@@ -1604,7 +1606,7 @@ cBitsUpTo' neg s n = (<?> systemName s) $ neg >>= \case
 {-# INLINE cBitsUpTo' #-}
 
 -- | A shorthand for 'cBitsUpTo'' 'optMinus'.
-cBitsUpTo ∷ (BitSystem s, Num α, Bits α, Monad μ, CharParsing μ)
+cBitsUpTo ∷ (BitSystem s, Num α, Bits α, MonadFail μ, CharParsing μ)
           ⇒ s → Int → μ α
 cBitsUpTo = cBitsUpTo' optMinus
 {-# INLINE cBitsUpTo #-}
@@ -1613,7 +1615,7 @@ cBitsUpTo = cBitsUpTo' optMinus
 --   positional numeral system, failing on overflow. The supplied parser is
 --   used to determine the sign of the number.
 bBits' ∷ (BitSystem s, Ord α, Bounded α, Num α, Bits α,
-          Monad μ, CharParsing μ)
+          MonadFail μ, CharParsing μ)
        ⇒ μ Sign → s → μ α
 bBits' neg s = (<?> systemName s) $ neg >>= \case
   NonNegative → nnbBits s
@@ -1622,7 +1624,7 @@ bBits' neg s = (<?> systemName s) $ neg >>= \case
 
 -- | A shorthand for 'bBits'' 'optMinus'.
 bBits ∷ (BitSystem s, Ord α, Bounded α, Num α, Bits α,
-         Monad μ, CharParsing μ)
+         MonadFail μ, CharParsing μ)
       ⇒ s → μ α
 bBits = bBits' optMinus
 {-# INLINE bBits #-}
@@ -1632,7 +1634,7 @@ bBits = bBits' optMinus
 --   used to determine the sign of the number. Leading zeroes are not
 --   allowed.
 cbBits' ∷ (BitSystem s, Ord α, Bounded α, Num α, Bits α,
-           Monad μ, CharParsing μ)
+           MonadFail μ, CharParsing μ)
         ⇒ μ Sign → s → μ α
 cbBits' neg s = (<?> systemName s) $ neg >>= \case
   NonNegative → nncbBits s
@@ -1641,7 +1643,7 @@ cbBits' neg s = (<?> systemName s) $ neg >>= \case
 
 -- | A shorthand for 'cbBits'' 'optMinus'.
 cbBits ∷ (BitSystem s, Ord α, Bounded α, Num α, Bits α,
-          Monad μ, CharParsing μ)
+          MonadFail μ, CharParsing μ)
        ⇒ s → μ α
 cbBits = cbBits' optMinus
 {-# INLINE cbBits #-}

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -11,7 +11,7 @@ import Prelude hiding (print)
 import Data.Word (Word)
 import Data.Fixed (Pico)
 import Type.Hint
-import Control.Applicative
+import Control.Monad.Fail (MonadFail)
 import Text.Printer (StringBuilder)
 import qualified Text.Printer as TP
 import qualified Text.Printer.Integral as TP
@@ -294,10 +294,10 @@ main = defaultMain
         parse fractional (print i) == Parsed (i ∷ Double)
   ]
 
-parse ∷ (∀ μ . (Monad μ, CharParsing μ) ⇒ μ α) → StringBuilder → Parsed α
+parse ∷ (∀ μ . (MonadFail μ, CharParsing μ) ⇒ μ α) → StringBuilder → Parsed α
 parse p b = builtInParser (p <* PC.eof) (TP.buildString b)
 
-parseAs ∷ p α → (∀ μ . (Monad μ, CharParsing μ) ⇒ μ α) → StringBuilder
+parseAs ∷ p α → (∀ μ . (MonadFail μ, CharParsing μ) ⇒ μ α) → StringBuilder
         → Parsed α
 parseAs _ = parse
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE UnicodeSyntax #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
@@ -8,10 +9,11 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.QuickCheck ((==>))
 
 import Prelude hiding (print)
-import Data.Word (Word)
 import Data.Fixed (Pico)
 import Type.Hint
+#if !MIN_VERSION_base(4, 13, 0)
 import Control.Monad.Fail (MonadFail)
+#endif
 import Text.Printer (StringBuilder)
 import qualified Text.Printer as TP
 import qualified Text.Printer.Integral as TP


### PR DESCRIPTION
`fail` is removed from `Monad` since base of GHC 8.8.

I have tested with GHC 8.4, 8.6, 8.8.

fixes #2